### PR TITLE
Append to body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /lib
 /standalone/dist
 .DS_Store
+yarn.lock

--- a/example/src/index.html
+++ b/example/src/index.html
@@ -98,6 +98,11 @@
                 <br />
                 <a href="https://github.com/michitaro/vue-window/blob/master/example/src/sample6.vue" target="_blank">(code)</a>
             </li>
+            <li>
+                <a href="?Sample8">append to body</a>
+                <br />
+                <a href="https://github.com/luucvanderzee/vue-window/blob/master/example/src/sample8.vue" target="_blank">(code)</a>
+            </li>
         </ul>
         <a class="github" href="https://github.com/michitaro/vue-window" target="_blank">View on Github</a>
     </footer>

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -7,6 +7,7 @@ import Sample4 from "./sample4.vue"
 import Sample5 from "./sample5.vue"
 import Sample6 from "./sample6.vue"
 import Sample7 from "./sample7.vue"
+import Sample8 from "./sample8.vue"
 
 
 Vue.use(VueWindow)
@@ -21,6 +22,7 @@ window.addEventListener('load', e => {
         Sample5,
         Sample6,
         Sample7,
+        Sample8
     } as any)[location.search.substr(1)] || Sample1
     new Vue({
         el: emptyElement(),

--- a/example/src/sample8.vue
+++ b/example/src/sample8.vue
@@ -31,7 +31,27 @@
                     title="Window 2"
                     :closeButton="true"
                     :isOpen.sync="isOpen2"
-                    :append-to-body="appendToBody">
+                    :append-to-body="false"
+                    :top="150"
+                    :left="100">
+                    Parameters:
+                    <fieldset>
+                        <legend>&alpha;</legend>
+                        <input type="range" />
+                    </fieldset>
+                    <fieldset>
+                        <legend>&beta;</legend>
+                        <input type="range" />
+                    </fieldset>
+                </hsc-window>
+
+                <hsc-window
+                    title="Window 3"
+                    :closeButton="true"
+                    :isOpen.sync="isOpen3"
+                    :append-to-body="true"
+                    :top="150"
+                    :left="100">
                     Parameters:
                     <fieldset>
                         <legend>&alpha;</legend>
@@ -45,17 +65,17 @@
 
             </hsc-window-style-metal>
 
-            <button @click="isOpen2 = ! isOpen2">Toggle Window 2 from sidebar</button>
+            <button
+                class="toggle-window-button"
+                @click="isOpen2 = ! isOpen2">
+                Toggle Window 2 (appendToBody = false)
+            </button>
 
-            <div style="margin-top: 30px;">
-                <label for="appendToBody">Append to body</label>
-                <input
-                    v-model="appendToBody"
-                    type="checkbox"
-                    name="Append to body"
-                    id="appendToBody"
-                />
-            </div>
+            <button
+                class="toggle-window-button"
+                @click="isOpen3 = ! isOpen3">
+                Toggle Window 3 (appendToBody = true)
+            </button>
 
         </div>
 
@@ -69,7 +89,7 @@ export default <any>{
         return {
             isOpen1: true,
             isOpen2: false,
-            appendToBody: false
+            isOpen3: false
         }
     },
 }
@@ -79,9 +99,12 @@ export default <any>{
 .side-bar {
   position: absolute;
   right: 0px;
-  width: 150px;
+  width: 300px;
   height: 85%;
   padding: 20px 20px;
   background-color: #d3d3d3;
+}
+.toggle-window-button {
+  margin-top: 30px;
 }
 </style>

--- a/example/src/sample8.vue
+++ b/example/src/sample8.vue
@@ -69,7 +69,7 @@ export default <any>{
         return {
             isOpen1: true,
             isOpen2: false,
-            appendToBody: true
+            appendToBody: false
         }
     },
 }

--- a/example/src/sample8.vue
+++ b/example/src/sample8.vue
@@ -1,0 +1,87 @@
+<template>
+    <div>
+
+        <hsc-window-style-metal>
+
+            <hsc-window
+                title="Window 1"
+                :closeButton="true"
+                :isOpen.sync="isOpen1">
+                Parameters:
+                <fieldset>
+                    <legend>&alpha;</legend>
+                    <input type="range" />
+                </fieldset>
+                <fieldset>
+                    <legend>&beta;</legend>
+                    <input type="range" />
+                </fieldset>
+            </hsc-window>
+
+            <button @click="isOpen1 = ! isOpen1">Toggle Window 1</button>
+
+        </hsc-window-style-metal>
+
+
+        <div class="side-bar">
+
+            <hsc-window-style-metal>
+
+                <hsc-window
+                    title="Window 2"
+                    :closeButton="true"
+                    :isOpen.sync="isOpen2"
+                    :append-to-body="appendToBody">
+                    Parameters:
+                    <fieldset>
+                        <legend>&alpha;</legend>
+                        <input type="range" />
+                    </fieldset>
+                    <fieldset>
+                        <legend>&beta;</legend>
+                        <input type="range" />
+                    </fieldset>
+                </hsc-window>
+
+            </hsc-window-style-metal>
+
+            <button @click="isOpen2 = ! isOpen2">Toggle Window 2 from sidebar</button>
+
+            <div style="margin-top: 30px;">
+                <label for="appendToBody">Append to body</label>
+                <input
+                    v-model="appendToBody"
+                    type="checkbox"
+                    name="Append to body"
+                    id="appendToBody"
+                />
+            </div>
+
+        </div>
+
+    </div>
+</template>
+
+
+<script lang="ts">
+export default <any>{
+    data() {
+        return {
+            isOpen1: true,
+            isOpen2: false,
+            appendToBody: true
+        }
+    },
+}
+</script>
+
+<style lang="scss" scoped>
+.side-bar {
+  position: absolute;
+  right: 0px;
+  width: 150px;
+  height: 85%;
+  padding: 20px 20px;
+  background-color: #d3d3d3;
+}
+</style>

--- a/src/window/script.ts
+++ b/src/window/script.ts
@@ -149,23 +149,15 @@ export class WindowType extends Vue {
                 this.resizable && this.initResizeHelper()
             })
             this.activateWhenOpen && this.activate()
+            if (this.appendToBody) {
+                document.body.appendChild(this.$el)
+            }
         }
     }
 
     @Watch('zGroup')
     onZGroupChange() {
         this.zElement.group = this.zGroup
-    }
-
-    @Watch('appendToBody')
-    onAppendToBodyChange(appendToBody: boolean) {
-        if (appendToBody) {
-            document.body.appendChild(this.$el)
-        }
-
-        if (!appendToBody) {
-            this.$el.parentNode!.removeChild(this.$el)
-        }
     }
 
     fixPosition() {

--- a/src/window/script.ts
+++ b/src/window/script.ts
@@ -52,6 +52,9 @@ export class WindowType extends Vue {
     @Prop({ default: 'visible' })
     overflow!: string
 
+    @Prop({ type: Boolean, default: false })
+    appendToBody!: boolean
+
     @Inject(WINDOW_STYLE_KEY)
     windowStyle!: WindowStyle
 
@@ -67,6 +70,9 @@ export class WindowType extends Vue {
         this.zElement = new ZElement(this.zGroup, zIndex => this.zIndex = `${zIndex}`)
         this.isOpen && this.onIsOpenChange(true)
         windows.add(this)
+        if (this.appendToBody) {
+            document.body.appendChild(this.$el)
+        }
     }
 
     beforeDestroy() {
@@ -75,6 +81,10 @@ export class WindowType extends Vue {
         this.resizableHelper && this.resizableHelper.teardown()
         this.draggableHelper && this.draggableHelper.teardown()
         instances.splice(instances.indexOf(this), 1)
+        // if appendToBody is true, remove DOM node after destroy
+        if (this.appendToBody && this.$el && this.$el.parentNode) {
+            this.$el.parentNode.removeChild(this.$el)
+        }
     }
 
     windowElement() {
@@ -145,6 +155,17 @@ export class WindowType extends Vue {
     @Watch('zGroup')
     onZGroupChange() {
         this.zElement.group = this.zGroup
+    }
+
+    @Watch('appendToBody')
+    onAppendToBodyChange(appendToBody: boolean) {
+        if (appendToBody) {
+            document.body.appendChild(this.$el)
+        }
+
+        if (!appendToBody) {
+            this.$el.parentNode!.removeChild(this.$el)
+        }
     }
 
     fixPosition() {


### PR DESCRIPTION
Added `appendToBody` prop (inspired by the one in[ ElementUI](https://github.com/ElemeFE/element)'s [Dialog window](https://github.com/ElemeFE/element/blob/dev/packages/dialog/src/component.vue#L59)). 
This prop will remove the element from its current location in the DOM-tree and append it to the body node. As a result, windows can be defined anywhere, without being constrained by their parent node.
See `sample8.vue` for a demonstration.